### PR TITLE
Interface changes

### DIFF
--- a/lemur
+++ b/lemur
@@ -537,15 +537,15 @@ class LemurRunEnv():
 
     def log(self, msg, level=logging.DEBUG):
         if level == logging.DEBUG:
-            self.logger.debug(msg)
+            self.logger.debug(f"DEBUG:\t{msg}")
         elif level == logging.INFO:
-            self.logger.info(msg)
+            self.logger.info(f"INFO:\t{msg}")
         elif level == logging.WARNING:
-            self.logger.warning(msg)
+            self.logger.warning(f"WARNING:\t{msg}")
         elif level == logging.ERROR:
-            self.logger.error(msg)
+            self.logger.error(f"ERROR:\t{msg}")
         elif level == logging.CRITICAL:
-            self.logger.critical(msg)
+            self.logger.critical(f"CRITICAL:\t{msg}")
     
 
     @staticmethod

--- a/lemur
+++ b/lemur
@@ -114,6 +114,8 @@ class LemurRunEnv():
         )
         main_args.add_argument(
             "--aln-score",
+            '--aln-score', choices=['AS', 'edit', 'markov'], default='AS',
+            help='AS: Use SAM AS tag for score, edit: Use edit-type distribution for score, markov: Score CIGAR as markov chain',
             type=str
         )
         main_args.add_argument(
@@ -140,10 +142,6 @@ class LemurRunEnv():
             "--ref-weight",
             type=float,
             default=1.
-        )
-        main_args.add_argument(
-            "--minimap2-AS",
-            action="store_true",
         )
         #  Minimap2 specific arguments
         mm2_args = parser.add_argument_group(title="minimap2 arguments")
@@ -259,10 +257,9 @@ class LemurRunEnv():
 
 
     def build_alignment_model(self):
-        if self.args.minimap2_AS:
+        if self.args.aln_score == "AS":
             return 
-        
-        if self.args.aln_score == "markov":
+        elif self.args.aln_score == "markov":
             self.build_transition_mats()
         elif self.args.aln_score == "edit":
             self.edit_cigar = self.build_edit_cost()
@@ -392,7 +389,7 @@ class LemurRunEnv():
         the Likelihood values by Read-Target-Mapping, and another called `gene_stats_df' containing gene-wise
         summary stats over these Likelihoods, which are then mapped onto the Likelihood dataframe.
 
-        How exactly the Likelihood is calculated depends on the command line inputs, but if the `minimap2_AS` flag
+        How exactly the Likelihood is calculated depends on the command line inputs, but if `aln_score == "AS"`
         is True then the calculation is simply:
             log_P = log( Minimap2_AlignmentScore / [2 * Alignment-Length ])
 
@@ -417,7 +414,7 @@ class LemurRunEnv():
                     gene = aln.reference_name.split(":")[1].split("/")[-1]
                 cigar = aln.cigartuples
 
-                if self.args.minimap2_AS:
+                if self.args.aln_score == "AS":
                     log_P_score = np.log(aln_score / (2 * self.__get_aln_len(aln)))
                     P_rgs_data["log_P"].append(log_P_score)
 
@@ -432,7 +429,7 @@ class LemurRunEnv():
                 self.log(f"build_P_rgs_df extracted {i+1} reads", logging.DEBUG)
 
 
-        if not self.args.minimap2_AS:
+        if not self.args.aln_score == "AS":
             with Pool(self.args.num_threads) as pool:
                 if self.aln_score == "markov":
                     if self.by_gene:
@@ -482,7 +479,7 @@ class LemurRunEnv():
         if self.args.ref_weight != 0:
             self.P_rgs_df["log_P"] = gene_p_rgs_len_df["ref_len_weighted_log_P"]
 
-        if self.args.minimap2_AS:
+        if self.args.aln_score == "AS":
             self.P_rgs_df = self.P_rgs_df[(gene_p_rgs_len_df["aln_len_ratio"] >= self.args.min_aln_len_ratio) &
                                           (gene_p_rgs_len_df["log_P"]>=1.1*gene_p_rgs_len_df["max_log_P"]) & 
                                           (gene_p_rgs_len_df["log_P"]>=np.log(self.args.min_fidelity))]

--- a/lemur
+++ b/lemur
@@ -188,9 +188,9 @@ class LemurRunEnv():
             help="Will save abundance profile at every EM step"
         )
         misc_args.add_argument(
-            "--nof",
+            "--width-filter",
             action="store_true",
-            help="do not apply width filter"
+            help="Apply width filter"
         )
         misc_args.add_argument(
             "--gid-name",
@@ -646,7 +646,7 @@ class LemurRunEnv():
         n_reads = len(set(self.P_rgs_df.reset_index()["Read_ID"]))
         self.low_abundance_threshold = 1. / n_reads
         
-        if not self.args.nof:
+        if self.args.width_filter:
             __P_rgs_df = self.P_rgs_df.reset_index()
             tids = list(self.F.index)
             filter_pass = []

--- a/lemur
+++ b/lemur
@@ -81,6 +81,7 @@ class LemurRunEnv():
             Lemur example:
             python lemur.py -i <input> -o <output_dir> -t <threads>
             """)
+        parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__)
         
         main_args = parser.add_argument_group(title="Main Mob arguments")
         main_args.add_argument(

--- a/lemur
+++ b/lemur
@@ -548,7 +548,7 @@ class LemurRunEnv():
         elif level == logging.ERROR:
             self.logger.error(msg)
         elif level == logging.CRITICAL:
-            self.logger.error(msg)
+            self.logger.critical(msg)
     
 
     @staticmethod

--- a/lemur
+++ b/lemur
@@ -156,8 +156,8 @@ class LemurRunEnv():
             help='minibatch size for minimap2 mapping [500M]'
         )
         mm2_args.add_argument(
-            '--mm2-type', choices=['map-ont', 'map-pb', 'sr'], default='map-ont',
-            help='short-read: sr, Pac-Bio: map-pb, ONT: map-ont [map-ont]'
+            '--mm2-type', choices=['map-ont', 'map-hifi', 'map-pb', 'sr'], default='map-ont',
+            help='ONT: map-ont [map-ont], PacBio (hifi): map-hifi, PacBio (CLR): map-pb, short-read: sr'
         )
         # Verbosity/logging/additional info
         misc_args = parser.add_argument_group(title="Miscellaneous arguments")
@@ -227,8 +227,10 @@ class LemurRunEnv():
         '''
         db_sequence_file = os.path.join(self.args.db_prefix, 'species_taxid.fasta')
 
-        cmd_str = f"minimap2 -ax map-ont \
-                            -N 50 \
+        cmd_str = f"minimap2 \
+                            -ax {self.args.mm2_type} \
+                            -N {self.args.mm2_N} \
+                            -K {self.args.mm2_K} \
                             -p .9 \
                             -f 0 \
                             --sam-hit-only \

--- a/lemur
+++ b/lemur
@@ -178,11 +178,9 @@ class LemurRunEnv():
             type=str,
         )
         misc_args.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=1,
-            help="Logging level: 0 (DEBUG), 1 (INFO), 2 (ERROR)"
+            "--verbose",
+            action='store_true',
+            help="Enable DEBUG level logging"
         )
         misc_args.add_argument(
             "--save-intermediate-profile",
@@ -522,12 +520,10 @@ class LemurRunEnv():
         error_handler = logging.StreamHandler(stream=sys.stderr)
         error_handler.setLevel(logging.ERROR)
 
-        if self.args.verbosity < 1:
+        if self.args.verbose:
             handler.setLevel(logging.DEBUG)
-        elif self.args.verbosity == 1:
-            handler.setLevel(logging.INFO)
         else:
-            handler.setLevel(logging.ERROR)
+            handler.setLevel(logging.INFO)
 
         formatter = logging.Formatter("%(asctime)s %(message)s",
                                       datefmt="%Y-%m-%d %I:%M:%S %p")

--- a/lemur
+++ b/lemur
@@ -48,10 +48,6 @@ class LemurRunEnv():
                       5: 0.001}
 
 
-    def setup(self):
-        self.__init__()
-
-
     def __init__(self):
         self.CURRDATE = datetime.date.today().strftime('%Y-%m-%d')
         self.CURRTIME = datetime.date.today().strftime('%H:%M:%S')

--- a/lemur
+++ b/lemur
@@ -9,6 +9,7 @@ import logging
 import sys
 import signal
 import time
+import shutil
 import subprocess as subp
 from itertools import repeat
 from multiprocessing import Pool
@@ -64,9 +65,14 @@ class LemurRunEnv():
         if self.args.sam_input:
             self.sam_path = self.args.sam_input
         else:
-            self.sam_path = self.args.output + ".sam"
+            self.sam_path = self.args.output + "/reads.sam"
 
-        self.tsv_output_path = self.args.output + "-relative_abundance"
+        if os.path.exists(self.args.output):
+            self.log(f"Output directory {self.args.output} exists! Results will be overwritten...", logging.WARNING)
+            shutil.rmtree(self.args.output)
+        os.makedirs(self.args.output)
+
+        self.tsv_output_prefix = self.args.output + "/relative_abundance"
 
         self.lli_threshold = 0.01
         self.low_abundance_threshold = 0.0001
@@ -91,7 +97,7 @@ class LemurRunEnv():
             "-o",
             "--output",
             type=str,
-            default=f"mob_out_{self.CURRDATE}_{self.CURRTIME}",
+            default=f"mob_out_{self.CURRDATE}_{self.CURRTIME}/",
             help="Folder where the Mob output will be stored"
         )
         main_args.add_argument(
@@ -462,7 +468,7 @@ class LemurRunEnv():
         self.P_rgs_df["log_P"] = self.P_rgs_df["log_P"] * self.P_rgs_df["max_aln_len"] / self.P_rgs_df["aln_len"]
         self.P_rgs_df["max_log_P"] = self.P_rgs_df.groupby("Read_ID")["log_P"].transform('max')
 
-        self.P_rgs_df.to_csv(f"{self.args.output}_P_rgs_df_raw.tsv", sep='\t', index=False)
+        self.P_rgs_df.to_csv(f"{self.args.output}/P_rgs_df_raw.tsv", sep='\t', index=False)
 
         # Get gene-wise stats from the file `gene2len.tsv` and read them onto this dataframe...
         self.gene_stats_df = pd.read_csv(f"{self.args.db_prefix}/gene2len.tsv", sep='\t')
@@ -475,7 +481,7 @@ class LemurRunEnv():
 
         gene_p_rgs_len_df["ref_len_weighted_log_P"] = gene_p_rgs_len_df["log_P"] + \
                                                       self.args.ref_weight * np.log(gene_p_rgs_len_df["aln_len_ratio"])
-        gene_p_rgs_len_df.to_csv(f"{self.args.output}_gene_P_rgs_df_raw.tsv", sep='\t', index=False)
+        gene_p_rgs_len_df.to_csv(f"{self.args.output}/gene_P_rgs_df_raw.tsv", sep='\t', index=False)
         if self.args.ref_weight != 0:
             self.P_rgs_df["log_P"] = gene_p_rgs_len_df["ref_len_weighted_log_P"]
 
@@ -502,7 +508,7 @@ class LemurRunEnv():
         __df = self.P_rgs_df.reset_index().merge(__df_id_count, how="left", on="Read_ID")
         self.unique_mapping_support_tids = set(__df[__df["Map_Count"]==1]["Target_ID"])
         self.log(self.P_rgs_df)
-        self.P_rgs_df.reset_index().to_csv(f"{self.args.output}_P_rgs_df.tsv", sep='\t', index=False)
+        self.P_rgs_df.reset_index().to_csv(f"{self.args.output}/P_rgs_df.tsv", sep='\t', index=False)
         return self.P_rgs_df
 
 
@@ -688,7 +694,7 @@ class LemurRunEnv():
 
             if self.args.save_intermediate_profile:
                 intermediate_df = self.df_taxonomy.merge(self.F, how='right', left_index=True, right_index=True).reset_index()
-                intermediate_df.to_csv(f"{self.tsv_output_path}-EM-{i}.tsv", sep='\t', index=False)
+                intermediate_df.to_csv(f"{self.tsv_output_prefix}-EM-{i}.tsv", sep='\t', index=False)
 
             if lli_delta < self.lli_threshold:
                 self.log(f"Low abundance threshold: {self.low_abundance_threshold:.8f}", logging.INFO)
@@ -746,13 +752,13 @@ class LemurRunEnv():
 
     def freq_to_lineage_df(self):
         results_df = self.df_taxonomy.merge(self.final_F, how='right', left_index=True, right_index=True).reset_index()
-        results_df.to_csv(f"{self.tsv_output_path}.tsv", sep='\t', index=False)
+        results_df.to_csv(f"{self.tsv_output_prefix}.tsv", sep='\t', index=False)
         
         return results_df
 
 
     def collapse_rank(self):
-        df_emu = pd.read_csv(f"{self.tsv_output_path}.tsv", sep='\t')
+        df_emu = pd.read_csv(f"{self.tsv_output_prefix}.tsv", sep='\t')
         if self.rank not in self.TAXONOMY_RANKS:
             raise ValueError("Specified rank must be in list: {}".format(self.TAXONOMY_RANKS))
         keep_ranks = self.TAXONOMY_RANKS[self.TAXONOMY_RANKS.index(self.rank):]
@@ -768,7 +774,7 @@ class LemurRunEnv():
             df_emu_copy = df_emu_copy.replace({'-': 0})
             df_emu_copy = df_emu_copy.astype({'F': 'float'})
         df_emu_copy = df_emu_copy.groupby(keep_ranks, dropna=False).sum()
-        output_path = f"{self.tsv_output_path}-{self.rank}.tsv"
+        output_path = f"{self.tsv_output_prefix}-{self.rank}.tsv"
         df_emu_copy.to_csv(output_path, sep='\t')
         self.log(df_emu_copy.nlargest(30, ["F"]), logging.DEBUG)
         self.log(f"File generated: {output_path}\n", logging.DEBUG)


### PR DESCRIPTION
* `--minimap2-AS` is now default, and one of the choices in `--aln-score`
* The previous opt-out `--nof` is no opt-in `--width-filter`
* Output is now grouped into the directory provided. For details see commit [6836997](https://github.com/treangenlab/lemur/commit/6836997ba3d0e941582df21559193d5b26fdc1db)
* The `setup(self)` function was removed
* Logs are now prefixed by their level i.e. `INFO:    {msg}`
* `--verbosity INT` is now a binary flag `--verbose`, `INFO` by default and `DEBUG` if `--verbose`.
* `-v/--version` prints version and exits