### PR TITLE
pandas v3.0.1 merge error fix

### DIFF
--- a/lemur
+++ b/lemur
@@ -618,10 +618,17 @@ class LemurRunEnv():
 
         # 1) Merges the current frequency vector into the Likelihood df, creating a new df called
         #   P_tgr, i.e. P( target | read )
-        self.P_tgr = self.P_rgs_df.reset_index().merge(self.F,
-                                                       how="inner", 
-                                                       left_on="Target_ID", 
-                                                       right_index=True)        #Step 0: Merge-F-to_LL
+        tmp = self.P_rgs_df.reset_index()
+        tmp["Target_ID"] = tmp["Target_ID"].astype(str)
+
+        F = self.F.copy()
+        F.index = F.index.astype(str)
+
+        self.P_tgr = tmp.merge(F,
+                               how="inner",
+                               left_on="Target_ID",
+                               right_index=True)        #Step 0: Merge-F-to_LL
+        
         # t1 = datetime.datetime.now().timestamp()
 
         # 2) Compute Likelihood x Prior:
@@ -669,11 +676,7 @@ class LemurRunEnv():
         '''Workhorse function that runs the EM-algorithm one step at a time and determines when the convergence
         criteria has been met, stopping once it has.'''
         n_reads = len(set(self.P_rgs_df.reset_index()["Read_ID"]))
-        if n_reads == 0:
-            self.log(f"No alignments available for EM algorithm.\nVerify SAM file, {self.self.args.output}P_rgs_df_raw.tsv, and consider lowering --min-aln-len-ratio or --fidelity flags.", logging.ERROR)
-            exit(1)
-        else:
-            self.low_abundance_threshold = 1. / n_reads
+        self.low_abundance_threshold = 1. / n_reads
 
         if self.args.width_filter:
             __P_rgs_df = self.P_rgs_df.reset_index()


### PR DESCRIPTION
When testing some of the Somatem scripts, we recently installed lemur from bioconda and the recent pandas update to v3.0.1 has created `ValueError: You are trying to merge on int64 and str columns for key 'Target_ID'` in the `EM_step` function. 

See error here (partial copy from Somatem nextflow.log script):
[lemur_pandas_error.txt](https://github.com/user-attachments/files/25557623/lemur_pandas_error.txt)

To fix this, I made both `self.P_rgs_df.reset_index()` and `self.F` keys into strings before merging. 

Tested and works as before!

